### PR TITLE
refactor(test): Update test to use nyc instead of istanbul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 coverage
 package-lock.json
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "precommit": "npm test",
     "commit": "git-cz",
     "lint": "eslint --fix src/*.js",
-    "test": "istanbul cover -x *.test.js _mocha -- -R spec src/index.test.js",
+    "test": "nyc --reporter=html --reporter=text mocha",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -32,17 +33,19 @@
   "devDependencies": {
     "chai": "4.2.0",
     "commitizen": "3.0.5",
+    "coveralls": "^3.0.7",
     "cz-conventional-changelog": "2.1.0",
     "eslint": "5.10.0",
     "eslint-config-standard": "12.0.0",
     "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-node": "8.0.0",
+    "eslint-plugin-node": "10.0.0",
     "eslint-plugin-promise": "4.0.1",
     "eslint-plugin-standard": "4.0.0",
     "husky": "1.3.0",
     "istanbul": "0.4.5",
-    "mocha": "5.2.0",
-    "semantic-release": "15.13.0"
+    "mocha": "^5.2.0",
+    "nyc": "^14.1.1",
+    "semantic-release": "^15.13.28"
   },
   "czConfig": {
     "path": "node_modules/cz-conventional-changelog"

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 const describe = require('mocha').describe
 const it = require('mocha').it
 const expect = require('chai').expect
-const damascus = require('./index')
+const damascus = require('../src/index')
 
 describe('syria-districts', () => {
   describe('all', () => {
@@ -28,7 +28,7 @@ describe('syria-districts', () => {
       const randomItems = damascus.random(3)
       expect(randomItems).to.have.length(3)
 
-      randomItems.forEach((randomItem) => {
+      randomItems.forEach(randomItem => {
         expect(damascus.all).to.include(randomItem)
       })
     })


### PR DESCRIPTION
Update the code base to use nyc instead of istanbul since they are not supporting it anymore.

BREAKING CHANGE: pipelines will go green now

fix #44