### PR TITLE
ci: update semantic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 after_success:
   - npm run coverage
   - npm run semantic-release
+  - npm publish
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![MIT License][license-badge]][LICENSE]
 [![Semantic release][semantic-release]][semantic]
 [![Damascus package][npm-dm]][damascus]
+[![Coverage Status][coveralls-badge]][coveralls]
 
 Get random districts names of Damascus.
 
@@ -35,3 +36,5 @@ This library was developed by [Abdul-hadi Hawari](https://twitter.com/@hadabo) a
 [semantic]: https://www.npmjs.com/package/semantic-release
 [npm-dm]: https://img.shields.io/npm/dm/damascus.svg?style=flat-square
 [damascus]: https://www.npmjs.com/package/damascus
+[coveralls]: https://coveralls.io/github/hadabo/damascus?branch=master
+[coveralls-badge]: https://coveralls.io/repos/github/hadabo/damascus/badge.svg?branch=master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "damascus",
-  "version": "1.0.0",
+  "version": "0.0.0-development",
   "description": "Get random districts names of Damascus or all of them",
   "main": "src/index.js",
   "scripts": {
@@ -9,7 +9,7 @@
     "lint": "eslint --fix src/*.js",
     "test": "nyc --reporter=html --reporter=text mocha",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
update semantic release and add after success npm scripts to travis CI

BREAKING CHANGE: Semantic release should automate the release process for the next changes